### PR TITLE
Update the source.

### DIFF
--- a/comments.jsonp
+++ b/comments.jsonp
@@ -18,7 +18,7 @@ callback(
 
 { "name": "[Q]More than one question asked", "description": "It is preferred if you can post separate questions instead of combining your questions into one. That way, it helps the people answering your question and also others hunting for atleast one of your questions. Thanks!"},
 
-{ "name": "[Q]Nothing but a URL (and isn't spam) ", "description": "Whilst this may theoretically answer the question, <a href=\"http://meta.stackoverflow.com/q/8259\">it would be preferable</a> to include the essential parts of the answer here, and provide the link for reference."},
+{ "name": "[A]Nothing but a URL (and isn't spam) ", "description": "Whilst this may theoretically answer the question, <a href=\"http://meta.stackoverflow.com/q/8259\">it would be preferable</a> to include the essential parts of the answer here, and provide the link for reference."},
 
 ]
 )


### PR DESCRIPTION
IIRC, I was complaining that the nothing but a url option doesn't come up when i want to comment on answers, and I got the reason. It has a [Q]. It needs an [A]. Fixed it. :)
