### PR TITLE
Fixed meta link

### DIFF
--- a/comments.jsonp
+++ b/comments.jsonp
@@ -14,7 +14,7 @@ callback(
 
 { "name": "[Q]Forums ", "description": "Welcome to Ask Ubuntu! Question like this that are open ended should be posted in the <a href=\"http://ubuntuforums.org\">Ubuntu Forums</a>, please see the <a href=\"http://askubuntu.com/faq\">FAQ</a> for what is on-topic here, thanks!"},
 
-{ "name": "Half answer in a comment", "description": "Can you include a answer with instructions on how to do that? <a href=\"http://askubuntu.com/questions/2281/please-stop-posting-half-answers-and-dumb-advice-as-comments\">Leaving a half-answer as a comment</a> can often cause more harm than good. Thanks."},
+{ "name": "Half answer in a comment", "description": "Can you include a answer with instructions on how to do that? <a href=\"http://meta.askubuntu.com/questions/2281/please-stop-posting-half-answers-and-dumb-advice-as-comments\">Leaving a half-answer as a comment</a> can often cause more harm than good. Thanks."},
 
 { "name": "[Q]More than one question asked", "description": "It is preferred if you can post separate questions instead of combining your questions into one. That way, it helps the people answering your question and also others hunting for atleast one of your questions. Thanks!"},
 


### PR DESCRIPTION
There was a link to a meta question that was wrongly linking to askbuntu.com instead of meta.askubuntu.com
