### PR TITLE
Add "Answering a Duplicate" Answer AutoMessage

### DIFF
--- a/comments.jsonp
+++ b/comments.jsonp
@@ -41,6 +41,8 @@ callback(
 
 { "name": "[A]OP using an answer for further information", "description": "Please use the *Post answer* button only for actual answers. You should modify your original question to add additional information"},
 
+{ "name": "[A]Answering a duplicate", "description": "This question will probably be closed as a duplicate soon.  As a result, this answer may be deleted for cleanup purposes, or merged into the other question. Thanks!" },
+
 ]
 )
 


### PR DESCRIPTION
This replaces Pull Request #15, fixes an error, and correctly assigns this to be an Answer proforma comment.

This fixes errors and bugs addressed in #15, however this also corrects an uncaught problem of the item being placed as a [Q] item, rather than an [A] item.
