### PR TITLE
URL for build status image is incorrect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 In order to ensure quality and help prevent pull requests from breaking the script, we are using [travis-ci.org](http://travis-ci.org) for continuous integration testing. The current status is:
 
-![ProForma Continuous Integration Status](https://secure.travis-ci.org/nathan-osman/ProFormaComments.png)
+![ProForma Continuous Integration Status](https://secure.travis-ci.org/AskUbuntu/ProFormaComments.png)
 
 ## Overview
 


### PR DESCRIPTION
I made a rather silly mistake when making my previous pull request - the image that displays build status (in `README.md`) has the wrong URL. It points to the builds for my fork, not the official ProForma repository.

This PR corrects the URL.
